### PR TITLE
Fix map pin anchoring and add fullscreen control

### DIFF
--- a/treeview/index.html
+++ b/treeview/index.html
@@ -1290,15 +1290,11 @@
       width: 32px;
       height: 40px;
       cursor: pointer;
-      position: relative;
     }
 
     .dorm-marker-pin {
       width: 32px;
       height: 40px;
-      display: flex;
-      align-items: flex-start;
-      justify-content: center;
       filter: drop-shadow(0 3px 6px rgba(140, 21, 21, 0.35));
       transition: transform 0.25s cubic-bezier(0.22, 1, 0.36, 1), filter 0.25s ease;
     }
@@ -1309,8 +1305,9 @@
     }
 
     .dorm-marker-pin svg {
-      width: 100%;
-      height: 100%;
+      display: block;
+      width: 32px;
+      height: 40px;
     }
 
     .campus-map-back-btn {
@@ -1436,6 +1433,18 @@
 
     .campus-map-overlay-btn--secondary:hover {
       background: rgba(255, 255, 255, 0.18);
+    }
+
+    .campus-map-container:fullscreen,
+    .campus-map-container:-webkit-full-screen {
+      width: 100vw;
+      height: 100vh;
+      border-radius: 0;
+    }
+
+    .campus-map-container:fullscreen #campus-map,
+    .campus-map-container:-webkit-full-screen #campus-map {
+      height: 100vh;
     }
 
     [data-theme="dark"] .campus-map-card {
@@ -2607,6 +2616,7 @@
       });
 
       campusMap.addControl(new mapboxgl.NavigationControl({ showCompass: true }), "top-right");
+      campusMap.addControl(new mapboxgl.FullscreenControl({ container: document.querySelector(".campus-map-container") }), "top-right");
 
       campusMap.on("load", () => {
         DORM_COORDS.forEach((dorm) => {


### PR DESCRIPTION
## Summary
- Fix marker CSS that caused pins to drift when panning the map (removed conflicting `position: relative`)
- Add Mapbox fullscreen control button (top-right, next to zoom controls) scoped to the map container
- Add fullscreen CSS so the map fills the viewport cleanly when expanded

## Test plan
- [ ] Pan/zoom the map — pins should stay anchored to their dorm locations
- [ ] Click the fullscreen button (top-right) — map should expand to fill the screen
- [ ] Press Esc or click the button again to exit fullscreen
- [ ] Verify overlay and back button still work correctly in fullscreen mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)